### PR TITLE
Implement CLI Version Update Reminders

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release Package
 on:
   push:
-    # Sequence of patterns matched against refs/tags
+    branches:
+      - 'main'
+      # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,11 @@ var (
 	cfgFile string
 )
 
+const (
+	RepositoryUrl = "https://github.com/camerondurham/ch"
+)
+
+// TODO: cleanup skeleton code
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "ch",
@@ -32,6 +37,18 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	latestVersion, err := util.GetLatestVersion(util.GetRequest)
+	if err != nil {
+		util.DebugPrint(fmt.Sprintf("ignoring version check since error occured when retrieving latest version: %v\n", err))
+	}
+	if latestVersion != version.PkgVersion {
+		fmt.Printf("A new version of ch is available!\n"+
+			"You are running version %s but the latest version is %s."+
+			"\nSee %s instructions on upgrading.\n",
+			version.PkgVersion,
+			latestVersion,
+			RepositoryUrl)
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,9 +42,10 @@ func Execute() {
 	if err != nil {
 		util.DebugPrint(fmt.Sprintf("ignoring version check since error occured when retrieving latest version: %v\n", err))
 	} else if version.PkgVersion != "" && latestVersion != version.PkgVersion {
-		fmt.Printf("A new version of ch is available!\n"+
-			"You are running version %s but the latest version is %s."+
-			"\nSee %s instructions on upgrading.\n",
+		fmt.Printf(
+			"\tA new version of ch is available!\n"+
+				"\tYou are running version %s but the latest version is %s.\n"+
+				"\tSee %s instructions on upgrading.\n",
 			version.PkgVersion,
 			latestVersion,
 			RepositoryUrl)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,11 +37,11 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	// TODO: only check if user didn't specify they don't want upgrade reminders
 	latestVersion, err := util.GetLatestVersion(util.GetRequest)
 	if err != nil {
 		util.DebugPrint(fmt.Sprintf("ignoring version check since error occured when retrieving latest version: %v\n", err))
-	}
-	if latestVersion != version.PkgVersion {
+	} else if version.PkgVersion != "" && latestVersion != version.PkgVersion {
 		fmt.Printf("A new version of ch is available!\n"+
 			"You are running version %s but the latest version is %s."+
 			"\nSee %s instructions on upgrading.\n",
@@ -49,6 +49,7 @@ func Execute() {
 			latestVersion,
 			RepositoryUrl)
 	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cmd/util/version_check.go
+++ b/cmd/util/version_check.go
@@ -12,14 +12,16 @@ const (
 	ApiPath    = "https://api.github.com/repos/%s/releases/latest"
 )
 
+type callback func(string) (map[string]interface{}, error)
+
 func LatestVersion(repository string) string {
 	return fmt.Sprintf(ApiPath, repository)
 }
 
-func GetLatestVersion() (string, error) {
+func GetLatestVersion(getRequest callback) (string, error) {
 
 	url := LatestVersion(Repository)
-	data, err := GetRequest(url)
+	data, err := getRequest(url)
 	if err != nil {
 		DebugPrint(fmt.Sprintf("error making GET request: %v", err))
 		return "", err

--- a/cmd/util/version_check.go
+++ b/cmd/util/version_check.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	Repository = "camerondurham/ch"
+	ApiPath    = "https://api.github.com/repos/%s/releases/latest"
+)
+
+func LatestVersion(repository string) string {
+	return fmt.Sprintf(ApiPath, repository)
+}
+
+func GetLatestVersion() (string, error) {
+
+	url := LatestVersion(Repository)
+	data, err := GetRequest(url)
+	if err != nil {
+		DebugPrint(fmt.Sprintf("error making GET request: %v", err))
+		return "", err
+	}
+
+	tagName := data["tag_name"].(string)
+	return tagName, nil
+}
+
+func GetRequest(url string) (map[string]interface{}, error) {
+	res, err := http.Get(url)
+	if err != nil {
+		DebugPrint(fmt.Sprintf("error making API request for latest release: %v", err))
+		return nil, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		DebugPrint(fmt.Sprintf("error reading API response body: %v", err))
+		return nil, err
+	}
+	var data map[string]interface{}
+
+	if err = json.Unmarshal(body, &data); err != nil {
+		DebugPrint(fmt.Sprintf("error parsing json: %v", err))
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/cmd/util/version_check_test.go
+++ b/cmd/util/version_check_test.go
@@ -1,33 +1,9 @@
 package util
 
-import "testing"
-
-func TestGetLatestVersion(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    string
-		wantErr bool
-	}{
-		// TODO: remove this test after API gets bumped. I'm too lazy to handle mocking right now.
-		{
-			name:    "Nominal: basic testing",
-			want:    "v0.2.2",
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetLatestVersion()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetLatestVersion() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("GetLatestVersion() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
+import (
+	"fmt"
+	"testing"
+)
 
 func TestLatestVersion(t *testing.T) {
 	type args struct {
@@ -53,6 +29,53 @@ func TestLatestVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := LatestVersion(tt.args.repository); got != tt.want {
 				t.Errorf("LatestVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetLatestVersion(t *testing.T) {
+	type args struct {
+		getRequest callback
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Nominal",
+			args: args{
+				getRequest: func(s string) (map[string]interface{}, error) {
+					return map[string]interface{}{
+						"tag_name": "v0.2.2",
+					}, nil
+				},
+			},
+			want:    "v0.2.2",
+			wantErr: false,
+		},
+		{
+			name: "Error",
+			args: args{
+				getRequest: func(s string) (map[string]interface{}, error) {
+					return nil, fmt.Errorf("error making GET request")
+				},
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetLatestVersion(tt.args.getRequest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLatestVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetLatestVersion() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/cmd/util/version_check_test.go
+++ b/cmd/util/version_check_test.go
@@ -1,0 +1,59 @@
+package util
+
+import "testing"
+
+func TestGetLatestVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{
+		// TODO: remove this test after API gets bumped. I'm too lazy to handle mocking right now.
+		{
+			name:    "Nominal: basic testing",
+			want:    "v0.2.2",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetLatestVersion()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetLatestVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetLatestVersion() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLatestVersion(t *testing.T) {
+	type args struct {
+		repository string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Nominal: camerondurham/ch",
+			args: args{repository: "camerondurham/ch"},
+			want: "https://api.github.com/repos/camerondurham/ch/releases/latest",
+		},
+		{
+			name: "Nominal: ph3rin/sacc",
+			args: args{repository: "ph3rin/sacc"},
+			want: "https://api.github.com/repos/ph3rin/sacc/releases/latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LatestVersion(tt.args.repository); got != tt.want {
+				t.Errorf("LatestVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`GetLatestVersion()` will retrieve latest tag on the `$REPO/ch` from Github.

Does not implement [semantic version](https://semver.org/) checking. Naive solution simply checks to see if latest version != current package version.

Closes #13 .