### PR TITLE
Implementing #17: only run update checks for running and list commands

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -17,6 +17,8 @@ var listCmd = &cobra.Command{
 
 func ListCmd(cmd *cobra.Command, args []string) {
 
+	util.CheckLatestVersion()
+
 	envName := ""
 	if len(args) > 0 {
 		envName = args[0]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,10 +16,6 @@ var (
 	cfgFile string
 )
 
-const (
-	RepositoryUrl = "https://github.com/camerondurham/ch"
-)
-
 var rootCmd = &cobra.Command{
 	Use:     "ch",
 	Short:   "A simple container helper to create and manage Docker environments",
@@ -27,8 +23,6 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-
-	optionalVersionCheck()
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
@@ -64,38 +58,6 @@ func initConfig() {
 	viper.AutomaticEnv() // read in environment variables that match
 
 	if err := viper.ReadInConfig(); err == nil {
-		util.DebugPrint(fmt.Sprint("Using config file:", viper.ConfigFileUsed()))
-	}
-}
-
-func optionalVersionCheck() {
-	opts, err := util.GetConfigOpts()
-
-	if err != nil {
-		util.DebugPrint(fmt.Sprintf("error reading environment file: %v", err))
-		checkLatestVersion()
-	} else if v, ok := opts["checkversion"]; !ok || v.CheckVersion {
-		util.DebugPrint(fmt.Sprintf("checkversion: true or no checkversion option found\n"))
-		checkLatestVersion()
-	} else {
-		util.DebugPrint(fmt.Sprintf("parsed options: %v\n", opts))
-		util.DebugPrint(fmt.Sprintf("local package version: %s\nlatest version: %v\n", version.PkgVersion, v))
-	}
-}
-
-func checkLatestVersion() {
-	latestVersion, err := util.GetLatestVersion(util.GetRequest)
-	if err != nil {
-		util.DebugPrint(fmt.Sprintf("ignoring version check since error occured when retrieving latest version: %v\n", err))
-	} else if version.PkgVersion != "" && latestVersion != version.PkgVersion {
-		fmt.Printf(
-			"\tA new version of ch is available!\n"+
-				"\tYou are running version %s but the latest version is %s.\n"+
-				"\tSee %s instructions on upgrading.\n",
-			version.PkgVersion,
-			latestVersion,
-			RepositoryUrl)
-	} else {
-		util.DebugPrint(fmt.Sprintf("local package version: %s\nlatest version: %s\n", version.PkgVersion, latestVersion))
+		util.DebugPrint(fmt.Sprint("Using config file: ", viper.ConfigFileUsed()))
 	}
 }

--- a/cmd/running.go
+++ b/cmd/running.go
@@ -23,6 +23,9 @@ To see all running containers, run:
 }
 
 func RunningCmd(cmd *cobra.Command, args []string) {
+
+	util.CheckLatestVersion()
+
 	cli, err := util.NewCliClient()
 	if err != nil {
 		fmt.Printf("error: cannot create new CLI ApiClient: %v\n", err)
@@ -42,7 +45,10 @@ func RunningCmd(cmd *cobra.Command, args []string) {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	// TODO: only print if something is actually running
 	fmt.Fprintf(w, "ENVIRONMENT\tIMAGE NAME\tCREATED\n")
+
 	for _, info := range list {
 		now := time.Now().Unix()
 		elapsed := now - info.Created

--- a/cmd/util/version_check.go
+++ b/cmd/util/version_check.go
@@ -3,13 +3,15 @@ package util
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/camerondurham/ch/version"
 	"io"
 	"net/http"
 )
 
 const (
-	Repository = "camerondurham/ch"
-	ApiPath    = "https://api.github.com/repos/%s/releases/latest"
+	RepositoryUrl = "https://github.com/camerondurham/ch"
+	Repository    = "camerondurham/ch"
+	ApiPath       = "https://api.github.com/repos/%s/releases/latest"
 )
 
 type callback func(string) (map[string]interface{}, error)
@@ -52,4 +54,21 @@ func GetRequest(url string) (map[string]interface{}, error) {
 	}
 
 	return data, nil
+}
+
+func CheckLatestVersion() {
+	latestVersion, err := GetLatestVersion(GetRequest)
+	if err != nil {
+		DebugPrint(fmt.Sprintf("ignoring version check since error occured when retrieving latest version: %v\n", err))
+	} else if version.PkgVersion != "" && latestVersion != version.PkgVersion {
+		fmt.Printf(
+			"\tA new version of ch is available!\n"+
+				"\tYou are running version %s but the latest version is %s.\n"+
+				"\tSee %s instructions on upgrading.\n",
+			version.PkgVersion,
+			latestVersion,
+			RepositoryUrl)
+	} else {
+		DebugPrint(fmt.Sprintf("local package version: %s\nlatest version: %s\n", version.PkgVersion, latestVersion))
+	}
 }


### PR DESCRIPTION
Only run checks for `ch running` and `ch list` commands.

For now, likely to look into issues with reading in config file later to save time and work on another project. This should be minimally annoying to user if the message only appears on the two commands.

Closes #17 