### PR TITLE
Detect and download arm64 architecture

### DIFF
--- a/scripts/install-ch.sh
+++ b/scripts/install-ch.sh
@@ -79,11 +79,20 @@ function add_to_path() {
 precheck
 
 version=$(get_latest_release $repository)
+architecture=$(uname -m)
+operating_system=$(uname)
 zip_filename=
-if [ "$(uname)" = "Linux" ]; then
-  zip_filename="ch-linux-amd64.zip"
+if [ "$operating_system" = "Linux" ] && ( [ "$architecture" = "x86_64" ] || [ "$architecture" = "x86-64" ] ); then
+    zip_filename="ch-linux-amd64.zip"
+elif [ "$operating_system" = "Linux" ] && [ "$architecture" = "aarch64" ]; then
+    # aarch64 is supposedly the same as arm64 and containerd treats them the
+    # same so we should be good
+    # https://stackoverflow.com/a/47274698/4676641
+    zip_filename="ch-linux-arm64.zip"
+elif [ "$operating_system" = "Darwin" ] && [ "$architecture" = "arm64" ]; then
+    zip_filename="ch-darwin-arm64.zip"
 else
-  zip_filename="ch-darwin-amd64.zip"
+    zip_filename="ch-darwin-amd64.zip"
 fi
 
 release_url=$(get_release_url "$repository" "$version" "$zip_filename")
@@ -98,3 +107,4 @@ if ! echo "$PATH" | grep ${zip_filename%.*} > /dev/null ; then
 fi
 
 echo "Done! Try using ch with: ch --help"
+

--- a/scripts/install-ch.sh
+++ b/scripts/install-ch.sh
@@ -82,7 +82,7 @@ version=$(get_latest_release $repository)
 architecture=$(uname -m)
 operating_system=$(uname)
 zip_filename=
-if [ "$operating_system" = "Linux" ] && ( [ "$architecture" = "x86_64" ] || [ "$architecture" = "x86-64" ] ); then
+if [ "$operating_system" = "Linux" ] && { [ "$architecture" = "x86_64" ] || [ "$architecture" = "x86-64" ]; } then
     zip_filename="ch-linux-amd64.zip"
 elif [ "$operating_system" = "Linux" ] && [ "$architecture" = "aarch64" ]; then
     # aarch64 is supposedly the same as arm64 and containerd treats them the


### PR DESCRIPTION
Fix install script to support Linux `aarch64` and Darwin/MacOS `arm64` when detected.

From this [stack overflow answer](https://stackoverflow.com/a/47274698/4676641), arm64 and aarch64 are the same thing, just Apple decided to name theirs arm64.

Also, `containerd` normalizes the names to the same thing in their [source code](https://github.com/containerd/containerd/blob/894b81a4b802e4eb2a91d1ce216b8817763c29fb/platforms/platforms.go#L88-L89).

Tested:

- [x] Linux: Arch x86_64
- [x] Linux: Ubuntu Server aarch64 (Raspberry Pi 4)
- [x] Darwin: x86_64
- [ ] Darwin: arm64